### PR TITLE
Fix and speed up score routine

### DIFF
--- a/autowordl.py
+++ b/autowordl.py
@@ -92,16 +92,15 @@ def score(guess, answer):
     # and using a faster function in that case.
     result = ["."]*5
     lettercount=defaultdict(int)
-    for letter in answer:
-        lettercount[letter] += 1
     # Process the exact matches.
     for ii in range(5):
         if guess[ii] == answer[ii]:
             result[ii] = guess[ii]
-            lettercount[answer[ii]] -= 1
+        else:
+            lettercount[answer[ii]] += 1
     # Process the leftover "right letters in wrong position."
     for ii in range(5):
-        if lettercount[guess[ii]] > 0:
+        if result[ii] == '.' and lettercount[guess[ii]] > 0:
             result[ii] = guess[ii].lower()
             lettercount[guess[ii]] -= 1
     return ''.join(result)
@@ -157,7 +156,10 @@ def read_word_list(filename):
     print("Loaded %d words." % len(words))
     return words
 
-words = read_word_list('/usr/share/dict/american-english')
+try: 
+    words = read_word_list('/usr/share/dict/american-english')
+except:
+    words = read_word_list('/usr/share/dict/words')
 
 # A wordl game server, which picks a random secret answer, and responds to our guesses.
 class WordlGame:

--- a/test_score.py
+++ b/test_score.py
@@ -1,0 +1,17 @@
+import unittest
+
+from autowordl import score
+
+class TestScore(unittest.TestCase):
+    def test_nomatch(self):
+        self.assertEqual(score('BATHE','SPOON'), '.....')
+    
+    def test_fullmatch(self):
+        self.assertEqual(score('TRYST', 'TRYST'), 'TRYST')
+
+    def test_multiple(self):
+        # this was an error in the old code
+        self.assertEqual(score('DRINK', 'DANDY'), 'D..n.')
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The score function would sometimes fail if there are repeated letters in the answer. E.g., `score('DRINK', 'DANDY')` would return `'d..n.'` instead of `'D..n.'`. I fixed this, and also added a minor optimization that makes the `score` function about 10% faster. I also added a regression test along with a couple of other trivial tests, and added a failover dictionary file since I don't have `american-english` on my system.